### PR TITLE
I've made the following changes to address the AEC and speaker volume…

### DIFF
--- a/components/codec_board/board_cfg.txt
+++ b/components/codec_board/board_cfg.txt
@@ -88,4 +88,4 @@ camera: {type: dvp, xclk: 15, pclk: 13, vsync: 6, href: 7, d0: 11, d1: 9, d2: 8,
 Board: MUSE_RADIO
 i2c: {sda: 18, scl: 11}
 i2s: {mclk: 0, bclk: 5, ws: 16, dout: 17, din: 4}
-in_out: {codec: ES8388, pa: 46, use_mclk: 0, pa_gain:15, adc_input_sel: 0xf0}
+in_out: {codec: ES8388, pa: 46, use_mclk: 0, pa_gain:20, adc_input_sel: 0xf0}

--- a/components/codec_board/codec_init.c
+++ b/components/codec_board/codec_init.c
@@ -185,6 +185,15 @@ static int _i2s_init(uint8_t port, esp_codec_dev_type_t dev_type, codec_init_cfg
     int ret = i2s_new_channel(&chan_cfg, output == false ? NULL : &i2s_keep[port]->tx_handle,
                               input == false ? NULL : &i2s_keep[port]->rx_handle);
     ESP_LOGI(TAG, "tx:%p rx:%p", i2s_keep[port]->tx_handle, i2s_keep[port]->rx_handle);
+    if (i2s_keep[port]->tx_handle && i2s_keep[port]->rx_handle) {
+        ESP_LOGI(TAG, "Attempting to enable I2S loopback for port %d", port);
+        esp_err_t loopback_ret = i2s_channel_set_loopback(i2s_keep[port]->tx_handle, true);
+        if (loopback_ret == ESP_OK) {
+            ESP_LOGI(TAG, "I2S loopback enabled successfully for port %d", port);
+        } else {
+            ESP_LOGE(TAG, "Failed to enable I2S loopback for port %d, error: %d", port, loopback_ret);
+        }
+    }
     if (i2s_keep[port]->tx_handle) {
         if (init_cfg->out_mode == CODEC_I2S_MODE_STD) {
             ret = i2s_channel_init_std_mode(i2s_keep[port]->tx_handle, &std_cfg);


### PR DESCRIPTION
… for MUSE_RADIO:

- I enabled I2S peripheral loopback in `codec_init.c`. This should fix the AEC by allowing the ESP32 to send a reference signal to the audio processing algorithms.
- I increased `pa_gain` for MUSE_RADIO in `board_cfg.txt` to 20 (it was originally 6, then 15). This will further boost the speaker volume.
- I ensured MUSE_RADIO is configured for LIN1/RIN1 (Left Microphone) on the ES8388.
- This also includes the previous logging additions I made for runtime verification of audio settings.